### PR TITLE
Add missing awaits

### DIFF
--- a/extension/src/js/floater.js
+++ b/extension/src/js/floater.js
@@ -16,7 +16,7 @@ export async function tryGetFloatingTabAsync() {
             result.floatingTab = floatingTab;
             result.tabProps = tabProps;
         } catch (error) {
-            clearFloatingTab();
+            await clearFloatingTabAsync();
         }
     }
 
@@ -57,10 +57,9 @@ export async function floatTabAsync() {
                 "height": coordinates.height,
             });
 
-            await setFloatingTabAsync(tabProps);
-
             const parentWindowTitle = succeedingActiveTab.title;
             await sendMakeDialogRequestAsync(currentTab.title, parentWindowTitle);
+            await setFloatingTabAsync(tabProps);
         }
     }
 }
@@ -70,7 +69,7 @@ export async function unfloatTabAsync() {
 
     if (floatingTab) {
         await browser.tabs.move(tabProps.tabId, { windowId: tabProps.parentWindowId, index: tabProps.originalIndex });
-        clearFloatingTab();
+        await clearFloatingTabAsync();
     }
 }
 
@@ -92,8 +91,8 @@ export async function setFloatingTabAsync(tabProps) {
     await browser.storage.local.set({ floatingTabProperties: tabProps });
 }
 
-export function clearFloatingTab() {
-    browser.storage.local.remove(["floatingTabProperties"]);
+export async function clearFloatingTabAsync() {
+    await browser.storage.local.remove(["floatingTabProperties"]);
 }
 
 /**

--- a/extension/src/js/main.js
+++ b/extension/src/js/main.js
@@ -14,32 +14,32 @@ export async function loadOptionsAsync() {
     return optionsData.options;
 }
 
-function setDefaultOptions() {
-    browser.storage.sync.set({ options: constants.DefaultOptions });
+async function setDefaultOptionsAsync() {
+    await browser.storage.sync.set({ options: constants.DefaultOptions });
 
     if (constants.DefaultOptions.smartPositioningFollowTabSwitches) {
         browser.tabs.onActivated.addListener(activeTabChangedListenerAsync);
     }
 }
 
-function startup() {
-    floater.clearFloatingTab();
+async function startupAsync() {
+    await floater.clearFloatingTabAsync();
 }
 
-browser.runtime.onInstalled.addListener(() => {
-    startup();
-    setDefaultOptions();
+browser.runtime.onInstalled.addListener(async () => {
+    await startupAsync();
+    await setDefaultOptionsAsync();
 });
 
-browser.runtime.onStartup.addListener(() => {
-    startup();
+browser.runtime.onStartup.addListener(async () => {
+    await startupAsync();
 });
 
 browser.tabs.onRemoved.addListener(async closingTabId => {
     const { floatingTab } = await floater.tryGetFloatingTabAsync();
 
     if (floatingTab && floatingTab.id === closingTabId) {
-        floater.clearFloatingTab();
+        await floater.clearFloatingTabAsync();
     }
 });
 
@@ -48,7 +48,7 @@ browser.windows.onRemoved.addListener(async closingWindowId => {
 
     if (floatingTab && tabProps.parentWindowId === closingWindowId) {
         await browser.tabs.remove(floatingTab.id);
-        floater.clearFloatingTab();
+        await floater.clearFloatingTabAsync();
     }
 });
 


### PR DESCRIPTION
Closes #73

Instead of removing `await`s, I actually added some - all actions should complete fully before the event handlers return. Otherwise, in extreme circumstances there could be problems.