### PR TITLE
Port to Firefox

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "lint": "npx eslint src/js",
+    "run-ff": "./run_firefox.sh",
     "postinstall": "run-script-os",
     "postinstall:nix": "./postinstall.sh",
     "postinstall:windows": "postinstall.bat"

--- a/extension/package.json
+++ b/extension/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "scripts": {
     "lint": "npx eslint src/js",
-    "run-ff": "./run_firefox.sh",
+    "run-ff": "run-script-os",
+    "run-ff:nix": "./run_firefox.sh",
+    "run-ff:windows": "run_firefox.bat",
     "postinstall": "run-script-os",
     "postinstall:nix": "./postinstall.sh",
     "postinstall:windows": "postinstall.bat"

--- a/extension/run_firefox.bat
+++ b/extension/run_firefox.bat
@@ -1,0 +1,9 @@
+@echo off
+
+move src\\manifest.json src\\manifest_chrome.json
+move src\\manifest_firefox.json src\\manifest.json
+
+call web-ext run --source-dir=src
+
+move src\\manifest.json src\\manifest_firefox.json
+move src\\manifest_chrome.json src\\manifest.json

--- a/extension/run_firefox.sh
+++ b/extension/run_firefox.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+mv src/manifest.json src/manifest_chrome.json
+mv src/manifest_firefox.json src/manifest.json
+
+web-ext run --source-dir=src
+
+mv src/manifest.json src/manifest_firefox.json
+mv src/manifest_chrome.json src/manifest.json

--- a/extension/src/html/background.html
+++ b/extension/src/html/background.html
@@ -12,11 +12,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<script type="module" src="../libs/webextension-polyfill/browser-polyfill.min.js"></script>
-<script type="module" src="../js/main.js"></script>
-<script type="module" src="../js/companion.js"></script>
-<script type="module" src="../js/constants.js"></script>
-<script type="module" src="../js/logger.js"></script>
-<script type="module" src="../js/floater.js"></script>
-<script type="module" src="../js/notifier.js"></script>
-<script type="module" src="../js/positioning/positioner.js"></script>
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <script type="module" src="../libs/webextension-polyfill/browser-polyfill.min.js"></script>
+    <script type="module" src="../js/main.js"></script>
+    <script type="module" src="../js/companion.js"></script>
+    <script type="module" src="../js/constants.js"></script>
+    <script type="module" src="../js/logger.js"></script>
+    <script type="module" src="../js/floater.js"></script>
+    <script type="module" src="../js/notifier.js"></script>
+    <script type="module" src="../js/positioning/positioner.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/extension/src/html/options.html
+++ b/extension/src/html/options.html
@@ -343,7 +343,19 @@ limitations under the License.
 
             <div class="uk-margin-left uk-margin-small-top uk-grid-match" uk-grid>
                 <div class="uk-flex-middle">
-                    <a id="hotkeyChangeButton" href="#">Change...</a>
+                    <div>
+                        <a id="hotkeyChangeButton" href="#">Change...</a>
+                        <div hidden id="firefoxHotKeyChangeInfo" class="uk-inline uk-margin-small-left">
+                            <sup><span uk-icon="icon: question; ratio: 0.7"></span></sup>
+                            <div uk-drop>
+                                <div class="uk-card-small uk-card-body uk-card-default uk-text-left">
+                                    Firefox does not allow to open the Add-ons page via links. To change hotkeys, go
+                                    to the Add-ons page, click the cogwheel icon in the top right corner, and choose
+                                    'Manage Extension Shortcuts'.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="uk-width-expand"></div>
             </div>

--- a/extension/src/html/options.html
+++ b/extension/src/html/options.html
@@ -48,7 +48,7 @@ limitations under the License.
     </header>
 
     <section uk-height-viewport="expand: true" class="uk-margin-small-top">
-        <div class="uk-container uk-container-small uk-margin-small">
+        <div id="companionSection" class="uk-container uk-container-small uk-margin-small">
             <h3>Companion</h3>
 
             <div class="uk-margin-left uk-grid-match" uk-grid>
@@ -129,9 +129,7 @@ limitations under the License.
                         target="_blank"></a>
                 </div>
             </div>
-        </div>
 
-        <div class="uk-container uk-container-small uk-margin-small">
             <hr>
         </div>
 
@@ -366,15 +364,27 @@ limitations under the License.
                             <sup><span uk-icon="icon: question; ratio: 0.7"></span></sup>
                             <div uk-drop>
                                 <div class="uk-card-small uk-card-body uk-card-default">
-                                    <p>If enabled, the application collects logs. To view the browser extension logs, go
-                                        into the Extensions page, choose 'Details' for TabFloater, then click the
-                                        'html/background.html' link.</p>
-                                    <p>To view the companion logs, copy the below file path and open it in your favorite
-                                        text editor. Note: the file only exists if you have used the application with
-                                        debugging enabled.</p>
-                                    <p>It is recommended to only enable this option if you need to troubleshoot a
-                                        problem
-                                        with the application.</p>
+                                    <span id="chromeDebugInfo">
+                                        <p>If enabled, the application collects logs. To view the browser extension logs, go
+                                            to the Extensions page, choose 'Details' for TabFloater, then click the
+                                            'html/background.html' link. This will open the Developer Tools window.
+                                            Switch to the 'Console' tab to see the extension logs.</p>
+                                        <p>To view the companion logs, copy the below file path and open it in your favorite
+                                            text editor. Note: the file only exists if you have used the application with
+                                            debugging enabled.</p>
+                                        <p>It is recommended to only enable this option if you need to troubleshoot a
+                                            problem
+                                            with the application.</p>
+                                    </span>
+                                    <span hidden id="firefoxDebugInfo">
+                                        <p>If enabled, the application collects logs. To view the application logs, go
+                                            to the Add-ons page, click the cogwheel icon in the top right corner, choose
+                                            'Debug Add-ons', then click 'Inspect' for TabFloater. This will open the Developer
+                                            Tools window. Switch to the 'Console' tab to see the extension logs.
+                                        <p>It is recommended to only enable this option if you need to troubleshoot a
+                                            problem
+                                            with the application.</p>
+                                    </span>
                                 </div>
                             </div>
                         </div>
@@ -391,7 +401,7 @@ limitations under the License.
                 </div>
             </div>
 
-            <div class="uk-margin-left uk-margin-small-top uk-grid-match uk-grid-collapse" uk-grid>
+            <div id="companionLogFileSection" class="uk-margin-left uk-margin-small-top uk-grid-match uk-grid-collapse" uk-grid>
                 <div class="uk-flex-middle uk-margin-medium-left">
                     Companion log file
                 </div>

--- a/extension/src/html/options.html
+++ b/extension/src/html/options.html
@@ -48,7 +48,7 @@ limitations under the License.
     </header>
 
     <section uk-height-viewport="expand: true" class="uk-margin-small-top">
-        <div id="companionSection" class="uk-container uk-container-small uk-margin-small">
+        <div class="uk-container uk-container-small uk-margin-small">
             <h3>Companion</h3>
 
             <div class="uk-margin-left uk-grid-match" uk-grid>
@@ -369,18 +369,18 @@ limitations under the License.
                                             to the Extensions page, choose 'Details' for TabFloater, then click the
                                             'html/background.html' link. This will open the Developer Tools window.
                                             Switch to the 'Console' tab to see the extension logs.</p>
+
+                                    </span>
+                                    <span hidden id="firefoxDebugInfo">
+                                        <p>If enabled, the application collects logs. To view the browser extension logs, go
+                                            to the Add-ons page, click the cogwheel icon in the top right corner, choose
+                                            'Debug Add-ons', then click 'Inspect' for TabFloater. This will open the Developer
+                                            Tools window. Switch to the 'Console' tab to see the extension logs.</p>
+                                    </span>
+                                    <span>
                                         <p>To view the companion logs, copy the below file path and open it in your favorite
                                             text editor. Note: the file only exists if you have used the application with
                                             debugging enabled.</p>
-                                        <p>It is recommended to only enable this option if you need to troubleshoot a
-                                            problem
-                                            with the application.</p>
-                                    </span>
-                                    <span hidden id="firefoxDebugInfo">
-                                        <p>If enabled, the application collects logs. To view the application logs, go
-                                            to the Add-ons page, click the cogwheel icon in the top right corner, choose
-                                            'Debug Add-ons', then click 'Inspect' for TabFloater. This will open the Developer
-                                            Tools window. Switch to the 'Console' tab to see the extension logs.
                                         <p>It is recommended to only enable this option if you need to troubleshoot a
                                             problem
                                             with the application.</p>
@@ -401,7 +401,7 @@ limitations under the License.
                 </div>
             </div>
 
-            <div id="companionLogFileSection" class="uk-margin-left uk-margin-small-top uk-grid-match uk-grid-collapse" uk-grid>
+            <div class="uk-margin-left uk-margin-small-top uk-grid-match uk-grid-collapse" uk-grid>
                 <div class="uk-flex-middle uk-margin-medium-left">
                     Companion log file
                 </div>

--- a/extension/src/html/options.html
+++ b/extension/src/html/options.html
@@ -377,21 +377,26 @@ limitations under the License.
                             <div uk-drop>
                                 <div class="uk-card-small uk-card-body uk-card-default">
                                     <span id="chromeDebugInfo">
-                                        <p>If enabled, the application collects logs. To view the browser extension logs, go
+                                        <p>If enabled, the application collects logs. To view the browser extension
+                                            logs, go
                                             to the Extensions page, choose 'Details' for TabFloater, then click the
                                             'html/background.html' link. This will open the Developer Tools window.
                                             Switch to the 'Console' tab to see the extension logs.</p>
 
                                     </span>
                                     <span hidden id="firefoxDebugInfo">
-                                        <p>If enabled, the application collects logs. To view the browser extension logs, go
+                                        <p>If enabled, the application collects logs. To view the browser extension
+                                            logs, go
                                             to the Add-ons page, click the cogwheel icon in the top right corner, choose
-                                            'Debug Add-ons', then click 'Inspect' for TabFloater. This will open the Developer
+                                            'Debug Add-ons', then click 'Inspect' for TabFloater. This will open the
+                                            Developer
                                             Tools window. Switch to the 'Console' tab to see the extension logs.</p>
                                     </span>
                                     <span>
-                                        <p>To view the companion logs, copy the below file path and open it in your favorite
-                                            text editor. Note: the file only exists if you have used the application with
+                                        <p>To view the companion logs, copy the below file path and open it in your
+                                            favorite
+                                            text editor. Note: the file only exists if you have used the application
+                                            with
                                             debugging enabled.</p>
                                         <p>It is recommended to only enable this option if you need to troubleshoot a
                                             problem

--- a/extension/src/html/options.html
+++ b/extension/src/html/options.html
@@ -351,7 +351,7 @@ limitations under the License.
                             <sup><span uk-icon="icon: question; ratio: 0.7"></span></sup>
                             <div uk-drop>
                                 <div class="uk-card-small uk-card-body uk-card-default uk-text-left">
-                                    Firefox does not allow to open the Add-ons page via links. To change hotkeys, go
+                                    Firefox does not allow opening the Add-ons page via links. To change hotkeys, go
                                     to the Add-ons page, click the cogwheel icon in the top right corner, and choose
                                     'Manage Extension Shortcuts'.
                                 </div>

--- a/extension/src/html/options.html
+++ b/extension/src/html/options.html
@@ -129,7 +129,9 @@ limitations under the License.
                         target="_blank"></a>
                 </div>
             </div>
+        </div>
 
+        <div class="uk-container uk-container-small uk-margin-small">
             <hr>
         </div>
 

--- a/extension/src/js/companion.js
+++ b/extension/src/js/companion.js
@@ -16,9 +16,16 @@
 
 import { CompanionName } from "./constants.js";
 import { CompanionLatestVersions } from "./constants.js";
-import { loadOptionsAsync } from "./main.js";
+import * as main from "./main.js";
 
 export async function getCompanionInfoAsync(logger) {
+    if (await main.runningOnFirefoxAsync()) {
+        return {
+            status: "n/a",
+            isOutdated: false
+        };
+    }
+
     try {
         const debug = await isDebuggingEnabledAsync();
         const companionInfo = await browser.runtime.sendNativeMessage(CompanionName, {
@@ -55,6 +62,13 @@ export async function getCompanionInfoAsync(logger) {
 }
 
 export async function sendMakeDialogRequestAsync(windowTitle, parentWindowTitle, logger) {
+    if (await main.runningOnFirefoxAsync()) {
+        logger.info("Running on Firefox - ignoring MakeDialog request");
+        return {
+            success: true
+        };
+    }
+
     logger.info(`MakeDialog request received. Window title: '${windowTitle}', parent window title: '${parentWindowTitle}'`);
 
     try {
@@ -106,6 +120,6 @@ function getMajorVersion(version) {
 }
 
 async function isDebuggingEnabledAsync() {
-    const options = await loadOptionsAsync();
+    const options = await main.loadOptionsAsync();
     return options.debug;
 }

--- a/extension/src/js/companion.js
+++ b/extension/src/js/companion.js
@@ -16,16 +16,9 @@
 
 import { CompanionName } from "./constants.js";
 import { CompanionLatestVersions } from "./constants.js";
-import * as main from "./main.js";
+import { loadOptionsAsync } from "./main.js";
 
 export async function getCompanionInfoAsync(logger) {
-    if (await main.runningOnFirefoxAsync()) {
-        return {
-            status: "n/a",
-            isOutdated: false
-        };
-    }
-
     try {
         const debug = await isDebuggingEnabledAsync();
         const companionInfo = await browser.runtime.sendNativeMessage(CompanionName, {
@@ -62,13 +55,6 @@ export async function getCompanionInfoAsync(logger) {
 }
 
 export async function sendMakeDialogRequestAsync(windowTitle, parentWindowTitle, logger) {
-    if (await main.runningOnFirefoxAsync()) {
-        logger.info("Running on Firefox - ignoring MakeDialog request");
-        return {
-            success: true
-        };
-    }
-
     logger.info(`MakeDialog request received. Window title: '${windowTitle}', parent window title: '${parentWindowTitle}'`);
 
     try {
@@ -120,6 +106,6 @@ function getMajorVersion(version) {
 }
 
 async function isDebuggingEnabledAsync() {
-    const options = await main.loadOptionsAsync();
+    const options = await loadOptionsAsync();
     return options.debug;
 }

--- a/extension/src/js/floater.js
+++ b/extension/src/js/floater.js
@@ -66,7 +66,7 @@ export async function floatTabAsync(logger) {
 
                 // We need to set the parent tab as active **before** the floating action happens,
                 // because this is the only way we can reliably inject the smart positioning
-                // content script into the parent tab
+                // content script into the parent tab.
                 try {
                     await browser.tabs.update(succeedingActiveTab.id, { active: true });
                 } catch (error) {
@@ -99,7 +99,9 @@ export async function floatTabAsync(logger) {
                     });
 
                     // Firefox prepends the URL of the page to the window title if the
-                    // window type is "popup", so we need to update it
+                    // window type is "popup", so we need to update it here. We can only
+                    // use the 'title' property on Firefox, because it's not defined on
+                    // Chrome for the 'Window' object.
                     floatingTabTitle = newWindow.title;
                 }
 

--- a/extension/src/js/floater.js
+++ b/extension/src/js/floater.js
@@ -88,7 +88,7 @@ export async function floatTabAsync(logger) {
                         "height": coordinates.height,
                     });
 
-                    // Firefox prepends the URL of the page to the window title, if the
+                    // Firefox prepends the URL of the page to the window title if the
                     // window type is "popup", so we need to update it
                     floatingTabTitle = newWindow.title;
                 }

--- a/extension/src/js/floater.js
+++ b/extension/src/js/floater.js
@@ -63,14 +63,7 @@ export async function floatTabAsync(logger) {
                 logger.info(`Will float current tab. TabProps: ${JSON.stringify(tabProps)}`);
 
                 const succeedingActiveTab = await getSucceedingActiveTabAsync();
-                try {
-                    await browser.tabs.update(succeedingActiveTab.id, { active: true });
-                } catch (error) {
-                    logger.error(`Unable to update active tab before floating action. Error: '${JSON.stringify(error)}'`);
-                }
-
                 const coordinates = await positioner.calculateCoordinatesAsync(logger);
-
                 const newWindow = await browser.windows.create({
                     "tabId": currentTab.id,
                     "type": "popup",

--- a/extension/src/js/floater.js
+++ b/extension/src/js/floater.js
@@ -63,6 +63,14 @@ export async function floatTabAsync(logger) {
                 logger.info(`Will float current tab. TabProps: ${JSON.stringify(tabProps)}`);
 
                 const succeedingActiveTab = await getSucceedingActiveTabAsync();
+
+                // TODO do we need this update here? maybe not!
+                try {
+                    await browser.tabs.update(succeedingActiveTab.id, { active: true });
+                } catch (error) {
+                    logger.error(`Unable to update active tab before floating action. Error: '${JSON.stringify(error)}'`);
+                }
+
                 const coordinates = await positioner.calculateCoordinatesAsync(logger);
                 const newWindow = await browser.windows.create({
                     "tabId": currentTab.id,

--- a/extension/src/js/floater.js
+++ b/extension/src/js/floater.js
@@ -99,8 +99,8 @@ export async function floatTabAsync(logger) {
                     });
 
                     // Firefox prepends the URL of the page to the window title if the
-                    // window type is "popup", so we need to update it here. We can only
-                    // use the 'title' property on Firefox, because it's not defined on
+                    // window type is "popup", so we need to update it here. We can use
+                    // the 'title' property only on Firefox, because it's not defined on
                     // Chrome for the 'Window' object.
                     floatingTabTitle = newWindow.title;
                 }

--- a/extension/src/js/floater.js
+++ b/extension/src/js/floater.js
@@ -63,6 +63,16 @@ export async function floatTabAsync(logger) {
                 logger.info(`Will float current tab. TabProps: ${JSON.stringify(tabProps)}`);
 
                 const succeedingActiveTab = await getSucceedingActiveTabAsync();
+
+                // We need to set the parent tab as active **before** the floating action happens,
+                // because this is the only way we can reliably inject the smart positioning
+                // content script into the parent tab
+                try {
+                    await browser.tabs.update(succeedingActiveTab.id, { active: true });
+                } catch (error) {
+                    logger.error(`Unable to update active tab before floating action. Error: '${JSON.stringify(error)}'`);
+                }
+
                 const coordinates = await positioner.calculateCoordinatesAsync(logger);
                 const newWindow = await browser.windows.create({
                     "tabId": currentTab.id,

--- a/extension/src/js/main.js
+++ b/extension/src/js/main.js
@@ -35,6 +35,15 @@ export async function loadOptionsAsync() {
     return optionsData.options;
 }
 
+export async function runningOnFirefoxAsync() {
+    if (browser.runtime.getBrowserInfo) {
+        const browserInfo = await browser.runtime.getBrowserInfo();
+        return browserInfo.name.toLowerCase().includes("firefox");
+    }
+
+    return false;
+}
+
 async function setDefaultOptionsAsync() {
     await browser.storage.sync.set({ options: constants.DefaultOptions });
 

--- a/extension/src/js/main.js
+++ b/extension/src/js/main.js
@@ -149,6 +149,7 @@ browser.runtime.onMessage.addListener(async request => {
         case "getCompanionInfo": return await getCompanionInfoAsync(logger);
         case "loadOptions": return await loadOptionsAsync();
         case "getHotkeys": return await browser.commands.getAll();
+        case "runningOnFirefox": return await runningOnFirefoxAsync();
     }
 });
 

--- a/extension/src/js/options.js
+++ b/extension/src/js/options.js
@@ -125,7 +125,7 @@ function setCompanionFields(companionInfo) {
     }
 }
 
-async function setHotKeysFieldsAsync(positioningStrategy, runningOnFirefox) {
+async function setHotKeysLabelsAsync(positioningStrategy) {
     const hotkeys = await browser.runtime.sendMessage("getHotkeys");
     const moveDownHotKey = hotkeys.filter(k => k.name === "moveDown")[0];
     const moveUpHotKey = hotkeys.filter(k => k.name === "moveUp")[0];
@@ -149,15 +149,6 @@ async function setHotKeysFieldsAsync(positioningStrategy, runningOnFirefox) {
         hotkeyMoveLeft.textContent = "";
         hotkeyMoveRightDescription.textContent = "Unused";
         hotkeyMoveRight.textContent = "";
-    }
-
-    if (runningOnFirefox) {
-        firefoxHotKeyChangeInfo.hidden = false;
-        hotkeyChangeButton.classList.add("uk-link-muted");
-    } else {
-        hotkeyChangeButton.onclick = function () {
-            browser.tabs.create({ url: "chrome://extensions/shortcuts/" });
-        };
     }
 }
 
@@ -188,7 +179,15 @@ window.onload = async function () {
     followTabSwitchCheckbox.checked = options.smartPositioningFollowTabSwitches;
     restrictMaxFloatingTabSizeCheckbox.checked = options.smartPositioningRestrictMaxFloatingTabSize;
 
-    await setHotKeysFieldsAsync(options.positioningStrategy, runningOnFirefox);
+    await setHotKeysLabelsAsync(options.positioningStrategy);
+    if (runningOnFirefox) {
+        firefoxHotKeyChangeInfo.hidden = false;
+        hotkeyChangeButton.classList.add("uk-link-muted");
+    } else {
+        hotkeyChangeButton.onclick = function () {
+            browser.tabs.create({ url: "chrome://extensions/shortcuts/" });
+        };
+    }
 
     debugCheckbox.checked = options.debug;
     if (runningOnFirefox) {

--- a/extension/src/js/options.js
+++ b/extension/src/js/options.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-const companionSection = window.companionSection;
 const companionStatusIndicatorConnected = window.companionStatusIndicatorConnected;
 const companionStatusIndicatorUnavailable = window.companionStatusIndicatorUnavailable;
 const companionUnavailableMessage = window.companionUnavailableMessage;
@@ -46,7 +45,6 @@ const hotkeyChangeButton = window.hotkeyChangeButton;
 const debugCheckbox = window.debugCheckbox;
 const chromeDebugInfo = window.chromeDebugInfo;
 const firefoxDebugInfo = window.firefoxDebugInfo;
-const companionLogFileSection = window.companionLogFileSection;
 const companionLogFileField = window.companionLogFileField;
 const copyCompanionLogFilePathButton = window.copyCompanionLogFilePathButton;
 const copyCompanionLogFilePathSuccessIcon = window.copyCompanionLogFilePathSuccessIcon;
@@ -123,11 +121,6 @@ function setCompanionFields(companionInfo) {
             downloadCompanionLink.textContent = "Get the companion...";
             companionLogFileField.value = "";
         } break;
-        case "n/a": {
-            // Running on Firefox - no need for companion
-            companionSection.hidden = true;
-            companionLogFileSection.hidden = true;
-        } break;
     }
 }
 
@@ -167,6 +160,7 @@ function positioningStrategyChanged() {
 window.onload = async function () {
     const options = await browser.runtime.sendMessage("loadOptions");
     const companionInfo = await browser.runtime.sendMessage("getCompanionInfo");
+    const runningOnFirefox = await browser.runtime.sendMessage("runningOnFirefox");
 
     setCompanionFields(companionInfo);
 
@@ -187,7 +181,7 @@ window.onload = async function () {
     await setHotKeysLabelsAsync(options.positioningStrategy);
 
     debugCheckbox.checked = options.debug;
-    if (companionInfo.status === "n/a") {
+    if (runningOnFirefox) {
         chromeDebugInfo.hidden = true;
         firefoxDebugInfo.hidden = false;
     }

--- a/extension/src/js/options.js
+++ b/extension/src/js/options.js
@@ -42,6 +42,7 @@ const hotkeyMoveLeft = window.hotkeyMoveLeft;
 const hotkeyMoveRightDescription = window.hotkeyMoveRightDescription;
 const hotkeyMoveRight = window.hotkeyMoveRight;
 const hotkeyChangeButton = window.hotkeyChangeButton;
+const firefoxHotKeyChangeInfo = window.firefoxHotKeyChangeInfo;
 const debugCheckbox = window.debugCheckbox;
 const chromeDebugInfo = window.chromeDebugInfo;
 const firefoxDebugInfo = window.firefoxDebugInfo;
@@ -124,7 +125,7 @@ function setCompanionFields(companionInfo) {
     }
 }
 
-async function setHotKeysLabelsAsync(positioningStrategy) {
+async function setHotKeysFieldsAsync(positioningStrategy, runningOnFirefox) {
     const hotkeys = await browser.runtime.sendMessage("getHotkeys");
     const moveDownHotKey = hotkeys.filter(k => k.name === "moveDown")[0];
     const moveUpHotKey = hotkeys.filter(k => k.name === "moveUp")[0];
@@ -148,6 +149,15 @@ async function setHotKeysLabelsAsync(positioningStrategy) {
         hotkeyMoveLeft.textContent = "";
         hotkeyMoveRightDescription.textContent = "Unused";
         hotkeyMoveRight.textContent = "";
+    }
+
+    if (runningOnFirefox) {
+        firefoxHotKeyChangeInfo.hidden = false;
+        hotkeyChangeButton.classList.add("uk-link-muted");
+    } else {
+        hotkeyChangeButton.onclick = function () {
+            browser.tabs.create({ url: "chrome://extensions/shortcuts/" });
+        };
     }
 }
 
@@ -178,7 +188,7 @@ window.onload = async function () {
     followTabSwitchCheckbox.checked = options.smartPositioningFollowTabSwitches;
     restrictMaxFloatingTabSizeCheckbox.checked = options.smartPositioningRestrictMaxFloatingTabSize;
 
-    await setHotKeysLabelsAsync(options.positioningStrategy);
+    await setHotKeysFieldsAsync(options.positioningStrategy, runningOnFirefox);
 
     debugCheckbox.checked = options.debug;
     if (runningOnFirefox) {
@@ -197,11 +207,6 @@ viewportTopOffsetInput.onblur = saveOptionsAsync;
 followTabSwitchCheckbox.onchange = saveOptionsAsync;
 restrictMaxFloatingTabSizeCheckbox.onchange = saveOptionsAsync;
 debugCheckbox.onchange = saveOptionsAsync;
-
-hotkeyChangeButton.onclick = function () {
-    browser.tabs.create({ url: "chrome://extensions/shortcuts/" });
-};
-
 copyCompanionLogFilePathButton.onclick = async function () {
     const logFilePath = companionLogFileField.value;
 

--- a/extension/src/js/positioning/positioner.js
+++ b/extension/src/js/positioning/positioner.js
@@ -94,8 +94,8 @@ async function getSmartPositionCoordinatesAsync(parentWindow, options, logger) {
     const parentWindowActiveTab = parentWindow.tabs.find(tab => tab.active);
 
     try {
-        await browser.tabs.executeScript(parentWindowActiveTab.id, { file: "libs/webextension-polyfill/browser-polyfill.min.js" });
-        await browser.tabs.executeScript(parentWindowActiveTab.id, { file: "js/positioning/areaCalculator.js" });
+        await browser.tabs.executeScript(parentWindowActiveTab.id, { file: "/libs/webextension-polyfill/browser-polyfill.min.js" });
+        await browser.tabs.executeScript(parentWindowActiveTab.id, { file: "/js/positioning/areaCalculator.js" });
 
         const coordinates = await browser.tabs.sendMessage(parentWindowActiveTab.id, {
             action: "calculateMaxEmptyArea",

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -11,6 +11,11 @@
         "https://*/*",
         "http://*/*"
     ],
+    "browser_specific_settings": {
+        "gecko": {
+          "id": "tabfloater@tabfloater.io"
+        }
+    },
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlazRJmLWlYBPmSrgf5gEmXPtTk6JDnTYtcgB685fp0rjBDZm8BJRtQcsk8wWL1w59ULFYsWGjPa0OSXJfx0xATWM9nX1SlRrXjkmEfQtFokFFq/blVVOU5gsXETBbJh2fGcmXhHxma0qa6/N3JKAMsymyDmfz8igIGWxBK3ps5J+y0Eeqxo2rV1ocnAcX23ieDNSZmUezv4bfpOrB9WJ8jTptkeWHdBj7myNAKpPUJV0Q6oechq96koUG3Dwh4Ru2rdSzWKsTkGh8hVvi38tRgg1E11AFhPammYigjOoWrGL4Ov4PGoRyugrVywAudFywKoHWkvyTiBDRqrW6GJUOwIDAQAB",
     "background": {
         "page": "html/background.html",

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -5,7 +5,6 @@
     "permissions": [
         "activeTab",
         "nativeMessaging",
-        "notifications",
         "storage",
         "tabs",
         "https://*/*",

--- a/extension/src/manifest_firefox.json
+++ b/extension/src/manifest_firefox.json
@@ -10,10 +10,13 @@
         "https://*/*",
         "http://*/*"
     ],
-    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlazRJmLWlYBPmSrgf5gEmXPtTk6JDnTYtcgB685fp0rjBDZm8BJRtQcsk8wWL1w59ULFYsWGjPa0OSXJfx0xATWM9nX1SlRrXjkmEfQtFokFFq/blVVOU5gsXETBbJh2fGcmXhHxma0qa6/N3JKAMsymyDmfz8igIGWxBK3ps5J+y0Eeqxo2rV1ocnAcX23ieDNSZmUezv4bfpOrB9WJ8jTptkeWHdBj7myNAKpPUJV0Q6oechq96koUG3Dwh4Ru2rdSzWKsTkGh8hVvi38tRgg1E11AFhPammYigjOoWrGL4Ov4PGoRyugrVywAudFywKoHWkvyTiBDRqrW6GJUOwIDAQAB",
+    "browser_specific_settings": {
+        "gecko": {
+          "id": "tabfloater@tabfloater.io"
+        }
+    },
     "background": {
-        "page": "html/background.html",
-        "persistent": false
+        "page": "html/background.html"
     },
     "browser_action": {
         "default_title": "Float tab!",


### PR DESCRIPTION
Fixes #23 
- Added a second manifest file for Firefox + logic to test in Firefox
- Hide companion related fields on Firefox
- Fixed FF incompatibility issues
- Removed active tab update before floating action - breaks Firefox UX and it doesn't seem to be necessary anymore in Chrome?